### PR TITLE
Implementing ERC721Enumerable.

### DIFF
--- a/abi/GenerationOmega.json
+++ b/abi/GenerationOmega.json
@@ -530,6 +530,49 @@
     "inputs": [
       {
         "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "index",
+        "type": "uint256"
+      }
+    ],
+    "name": "tokenOfOwnerByIndex",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "tokenId",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
         "name": "tokenId",
         "type": "uint256"
       }
@@ -540,6 +583,19 @@
         "internalType": "string",
         "name": "",
         "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",

--- a/contracts/library/ERC721B.sol
+++ b/contracts/library/ERC721B.sol
@@ -7,6 +7,7 @@ import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
@@ -14,7 +15,7 @@ import "@openzeppelin/contracts/utils/Address.sol";
  * @author: Squeebo *
  ********************/
 
-abstract contract ERC721B is Context, ERC165, IERC721, IERC721Metadata {
+abstract contract ERC721B is Context, ERC165, IERC721, IERC721Metadata, IERC721Enumerable {
   using Address for address;
 
   // Token name
@@ -53,6 +54,7 @@ abstract contract ERC721B is Context, ERC165, IERC721, IERC721Metadata {
     return
       interfaceId == type(IERC721).interfaceId ||
       interfaceId == type(IERC721Metadata).interfaceId ||
+      interfaceId == type(IERC721Enumerable).interfaceId ||
       super.supportsInterface(interfaceId);
   }
 
@@ -442,4 +444,52 @@ abstract contract ERC721B is Context, ERC165, IERC721, IERC721Metadata {
     address to,
     uint256 tokenId
   ) internal virtual {}
+
+  /**
+   * @dev See {IERC721Enumerable-totalSupply}.
+   */
+  function totalSupply()
+    public
+    view
+    virtual
+    override
+    returns (uint256)
+  {
+    return _owners.length;
+  }
+
+  /**
+   * @dev See {IERC721Enumerable-tokenByIndex}.
+   */
+  function tokenByIndex(uint256 index)
+    public
+    view
+    virtual
+    override
+    returns (uint256)
+  {
+    require(_exists(index), "ERC721: approved query for nonexistent token");
+    return index;
+  }
+
+  /**
+   * @dev See {IERC721Enumerable-tokenOfOwnerByIndex}.
+   */
+  function tokenOfOwnerByIndex(address owner, uint256 index)
+    public
+    view
+    virtual
+    override
+    returns (uint256 tokenId)
+  {
+    require(index < balanceOf(owner), "ERC721Enumerable: owner index out of bounds");
+    uint count;
+    for (uint i; i < _owners.length; i++) {
+      if (owner == _owners[i]) {
+        if (count == index) return i;
+        else count++;
+      }
+    }
+    require(false, "ERC721Enumerable: owner index out of bounds");
+  }
 }

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -13,11 +13,11 @@ const main = async () => {
 
   let txn = await contract.setRendererContractAddress(rendererContract.address);
   txn = await contract.ownerClaim(0);
-  console.log('tx', txn);
+  console.log('owner claim tx', txn);
   txn = await contract.toggleSaleStatus();
-  console.log('tx', txn);
-  txn = await contract.buy(1, { value: ethers.utils.parseEther("0.02") });
-  console.log('tx', txn);
+  console.log('enable sale tx', txn);
+  // txn = await contract.buy(1, { value: ethers.utils.parseEther("0.02") });
+  // console.log('tx', txn);
 };
 
 const runMain = async () => {

--- a/scripts/run.js
+++ b/scripts/run.js
@@ -14,8 +14,6 @@ const main = async () => {
   let txn = await contract.setRendererContractAddress(rendererContract.address);
   txn = await contract.ownerClaim(0);
   console.log('owner claim tx', txn);
-  txn = await contract.ownerClaim(1);
-  console.log('owner claim 2 tx', txn);
   txn = await contract.tokenURI(0);
   console.log('get token URI tx', txn);
   txn = await contract.remainingTokens();
@@ -23,11 +21,23 @@ const main = async () => {
   txn = await contract.toggleSaleStatus();
   console.log('enable sales tx', txn);
   txn = await contract.buy(1, { value: ethers.utils.parseEther("0.02") });
+  const fromAddr = txn.from;
   console.log('buy token tx', txn);
   txn = await contract.buy(1, { value: ethers.utils.parseEther("0.02") });
   console.log('buy token tx 2', txn);
   txn = await contract.remainingTokens();
   console.log('get count of remaining tokens 2 tx', txn);
+
+  // iterating over the tokens
+  console.log('Addr', fromAddr);
+  txn = await contract.balanceOf(fromAddr);
+  console.log('balance', txn);
+  const balance = txn;
+  for (let index = 0; index < balance; index++) {
+    txn = await contract.tokenOfOwnerByIndex(fromAddr, index);
+    console.log('index', index, txn);
+    // txn returned here can be fed into tokenURI function.
+  }
 };
 
 const runMain = async () => {


### PR DESCRIPTION
Adding support for the [enumerable interface](https://docs.openzeppelin.com/contracts/4.x/api/token/erc721#IERC721Enumerable) so a client can request the number of tokens owned by a wallet (`balanceOf`) and then iterate through them with `tokenOfOwnerByIndex`.

Example of retrieving token indexes in `scripts/run.js`.